### PR TITLE
Fix HTTP/HTTPS detection in utils

### DIFF
--- a/src/vulnscan/utils.py
+++ b/src/vulnscan/utils.py
@@ -22,9 +22,12 @@ def print_banner():
     print(f"{Fore.YELLOW}Use only on systems you own or have permission to test!{Style.RESET_ALL}")
 
 def check_http(ip: str, port: int) -> bool:
-    """Check if an HTTP service is running on the given IP and port"""
+    """Check if an HTTP or HTTPS service is running on the given IP and port"""
     try:
-        url = f"http://{ip}:{port}/"
+        scheme = "http"
+        if port in (443, 8443):
+            scheme = "https"
+        url = f"{scheme}://{ip}:{port}/"
         resp = requests.get(url, timeout=3, verify=False)
         return resp.status_code < 500
     except Exception:
@@ -33,7 +36,10 @@ def check_http(ip: str, port: int) -> bool:
 def check_directory_listing(ip: str, port: int) -> bool:
     """Check for directory listing vulnerability"""
     try:
-        url = f"http://{ip}:{port}/"
+        scheme = "http"
+        if port in (443, 8443):
+            scheme = "https"
+        url = f"{scheme}://{ip}:{port}/"
         resp = requests.get(url, timeout=3, verify=False)
         if "Index of /" in resp.text:
             return True


### PR DESCRIPTION
## Summary
- handle HTTPS ports correctly in `check_http` and `check_directory_listing`

## Testing
- `python3 -m py_compile src/vulnscan/*.py`
- `tests/run_all_tests.sh` *(fails: ModuleNotFoundError: No module named 'colorama')*

------
https://chatgpt.com/codex/tasks/task_e_684fe2c1c28c832fb8ed6575dc169d13